### PR TITLE
Added automatic build & release via GitHub actions

### DIFF
--- a/.github/workflows/build_qmake.yml
+++ b/.github/workflows/build_qmake.yml
@@ -1,0 +1,71 @@
+name: Build Matrix
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    env:
+      BUILD_NUMBER: ${{ github.run_number }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - name: "Windows 64bit"
+          artifact: "Windows-x64"
+          os: windows-latest
+
+        - name: "Ubuntu 16.04 64bit"
+          artifact: "Ubuntu-16.04"
+          os: ubuntu-16.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup Compiler on Windows
+      if: startsWith(matrix.config.os, 'windows')
+      uses: msys2/setup-msys2@v2
+      with:
+        update: false
+        
+    - name: Build on Windows
+      if: startsWith(matrix.config.os, 'windows')
+      run: |
+        cd ${{ github.workspace }}
+        gcc -std=gnu99 -m64 cpuconf.c cpuinfo.c -O2 -s -o cpuconf
+        cpuconf.exe -h -ccenv
+        windres bricksync.rc -O coff -o bricksync.res
+        gcc -std=gnu99 -I./build-win64/ -L./build-win64/ -m64 bricksync.c bricksyncconf.c bricksyncnet.c bricksyncinit.c bricksyncinput.c bsantidebug.c bsmessage.c bsmathpuzzle.c bsorder.c bsregister.c bsapihistory.c bstranslation.c bsevalgrade.c bsoutputxml.c bsorderdir.c bspriceguide.c bsmastermode.c bscheck.c bssync.c bsapplydiff.c bsfetchorderinv.c bsresolve.c bscatedit.c bsfetchinv.c bsfetchorderlist.c bsfetchset.c bscheckreg.c bsfetchpriceguide.c tcp.c vtlex.c cpuinfo.c antidebug.c mm.c mmhash.c mmbitmap.c cc.c ccstr.c debugtrack.c tcphttp.c oauth.c bricklink.c brickowl.c brickowlinv.c colortable.c json.c bsx.c bsxpg.c journal.c exclperm.c iolog.c crypthash.c cryptsha1.c rand.c bn512.c bn1024.c rsabn.c bricksync.res -O2 -s -fvisibility=hidden -o bricksync -lm -lwsock32 -lws2_32 -lssleay32 -leay32
+        echo "Compilation finished"
+        copy bricksync.exe "Releases\1.7.1\bricksync-win64"
+        echo "Copied"
+        tar.exe -acvf bricksync-win64-1.7.2-${{ github.run_number }}.zip -C "Releases\1.7.1" bricksync-win64
+        dir
+      shell: cmd
+      
+    - name: Upload on Windows
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.config.os, 'windows')
+      with:
+        name: ${{ matrix.config.artifact }}
+        path: "*.zip"
+
+    - name: Build on Linux
+      if: startsWith(matrix.config.os, 'ubuntu')
+      run: |
+        sudo apt-get install -y --allow-downgrades openssl=1.0.2g-1ubuntu4.19 libssl-dev=1.0.2g-1ubuntu4.19
+        chmod +x compile
+        bash -c ./compile
+        cp bricksync Releases/1.7.1/bricksync-linux64
+        tar -cvzf bricksync-linux64-1.7.2-${{ github.run_number}}.tar.gz -C Releases/1.7.1 bricksync-linux64
+      shell: bash
+
+    - name: Upload on Linux
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.config.os, 'ubuntu')
+      with:
+        name: ${{ matrix.config.artifact }}
+        path: "*.tar.gz"


### PR DESCRIPTION
I got fed up with people asking me to "fix" BrickStore just to support
bricksync:

Build a win64 and a linux64 version automatically via GitHub actions on
every commit. The usefulness of the linux64 one questionable, since
bricksync requires OpenSSL 1.0 and current distros don't ship that
anymore (the build is done on an Ubuntu 16.04 runner).

The generated packages are versioned as 1.7.2-\<github action run number\>