### PR TITLE
Add Timestamps to the startup printout and fetch messages

### DIFF
--- a/bricksync.h
+++ b/bricksync.h
@@ -24,7 +24,8 @@
 #define BS_VERSION_MAJOR (1)
 #define BS_VERSION_MINOR (7)
 #define BS_VERSION_REVISION (4)
-#define BS_VERSION_STRING "1.7.4-231110"
+// Release Major.Minor.Revision-<seconds from epoch for submission>
+#define BS_VERSION_STRING "1.7.4-1701389201"
 #define BS_VERSION_INTEGER_ENCODE(major,minor,revision) (((major)*10000)|((minor)*100)|((revision)*1))
 #define BS_VERSION_INTEGER BS_VERSION_INTEGER_ENCODE(BS_VERSION_MAJOR,BS_VERSION_MINOR,BS_VERSION_REVISION)
 

--- a/bricksyncinput.c
+++ b/bricksyncinput.c
@@ -21,6 +21,7 @@
  * -----------------------------------------------------------------------------
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -871,6 +872,13 @@ void bsCommandStatus( bsContext *context, int argc, char **argv )
   ccGrowth growth;
   char *colorstring;
   float apihistoryratio;
+  // Set the current date and time for printout in the startup message
+  time_t t = time(NULL);
+  struct tm *tm = localtime(&t);
+  char cur_date_time[64];
+  size_t ret = strftime(cur_date_time, sizeof(cur_date_time), "%Y-%m-%d %H:%M:%S", tm);
+  // validate pointer to the time value
+  assert(ret);
 
   if( !( bsCmdArgStdParse( context, argc, argv, 0, 0, 0, &cmdflags, BS_COMMAND_ARGSTD_FLAG_SHORT ) ) )
   {
@@ -883,6 +891,8 @@ void bsCommandStatus( bsContext *context, int argc, char **argv )
   if( !( cmdflags & BS_COMMAND_ARGSTD_FLAG_SHORT ) )
     ioPrintf( &context->output, 0, BSMSG_INFO "BrickSync Status Report.\n" );
   ioPrintf( &context->output, 0, BSMSG_INFO "Software version : " IO_GREEN "%s" IO_DEFAULT " - " IO_GREEN "%s %s" IO_DEFAULT ".\n", BS_VERSION_STRING, __DATE__, __TIME__ );
+  ioPrintf( &context->output, 0, BSMSG_INFO "Software launch time : " IO_CYAN "%s" IO_DEFAULT ".\n", cur_date_time);
+
   if( ( context->storename ) && ( context->username ) )
     ioPrintf( &context->output, 0, BSMSG_INFO "Store name : " IO_GREEN "%s" IO_DEFAULT " by " IO_GREEN "%s" IO_DEFAULT ".\n", context->storename, context->username );
   else if( context->storename )

--- a/bsfetchorderlist.c
+++ b/bsfetchorderlist.c
@@ -21,6 +21,7 @@
  * -----------------------------------------------------------------------------
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -70,7 +71,17 @@
 
 
 ////
+void getFetchTimeStamp(char *fetch_timestamp, int time_length)
+{
+    // Set the current date and time for printout in the fetch message
+    time_t t = time(NULL);
+    struct tm *tm = localtime(&t);
+    size_t ret = strftime(fetch_timestamp, time_length, "%Y-%m-%d %H:%M:%S", tm);
+    // validate pointer to the time value
+    assert(ret);
+    return;
 
+}
 
 static void bsBrickLinkReplyOrderList( void *uservalue, int resultcode, httpResponse *response )
 {
@@ -117,11 +128,14 @@ int bsQueryBickLinkOrderList( bsContext *context, bsOrderList *orderlist, int64_
 {
   bsQueryReply *reply;
   bsTracker tracker;
+  // Set the current date and time for printout in the fetch message
+  char bl_fetch_date_time[64];
+  getFetchTimeStamp(bl_fetch_date_time, 64);
 
   DEBUG_SET_TRACKER();
 
   bsTrackerInit( &tracker, context->bricklink.http );
-  ioPrintf( &context->output, IO_MODEBIT_FLUSH, BSMSG_INFO "Fetching the BrickLink Order List...\n" );
+  ioPrintf( &context->output, IO_MODEBIT_FLUSH, BSMSG_INFO "Fetching the BrickLink Order List (" IO_CYAN "%s" IO_DEFAULT ")...\n", bl_fetch_date_time);
   for( ; ; )
   {
     /* Add an OrderList query */
@@ -249,11 +263,14 @@ int bsQueryBickOwlOrderList( bsContext *context, bsOrderList *orderlist, int64_t
   char *querystring;
   bsTracker tracker;
   bsOrder *order;
+  // Set the current date and time for printout in the fetch message
+  char bo_fetch_date_time[64];
+  getFetchTimeStamp(bo_fetch_date_time, 64);
 
   DEBUG_SET_TRACKER();
 
   bsTrackerInit( &tracker, context->brickowl.http );
-  ioPrintf( &context->output, IO_MODEBIT_FLUSH, BSMSG_INFO "Fetching the BrickOwl Order List...\n" );
+  ioPrintf( &context->output, IO_MODEBIT_FLUSH, BSMSG_INFO "Fetching the BrickOwl Order List (" IO_CYAN "%s" IO_DEFAULT ")...\n", bo_fetch_date_time);
   for( ; ; )
   {
     /* Add an OrderList query */


### PR DESCRIPTION
This PR will add a new output to the startup message that will tell you the "Software Launch Time". It will also add time stamps to the INFO lines for when it does a fetch from Bricklink or BrickOwl.

This was added because the standard output did not show the fetch times - so - if the process had locked up (which happens periodically) - you could never really tell when it last made a pull - nor could you easily identify it was locked up.

The software version has been bumped to: 1.7.4-1701389201 where the last number is the seconds from epoch when the build occurred. I saw the last builds were using the DATE STAMP (i.e. Nov 10, 2023 thus the build was 231110) so you can swap the build number to 231130 - if that make more sense on release.

Example output with the new fields highlight in yellow as call outs:
![image](https://github.com/ZZJHONS/Bricksync/assets/26184942/4c850846-951a-49e4-b0f0-ea53332c95be)



