### PR TITLE
Fix "Software launch time" to be accurate when 'status' command called from console.

### DIFF
--- a/bricksync.c
+++ b/bricksync.c
@@ -1035,6 +1035,8 @@ int main( int argc, char **argv )
 
   mmInit();
   cpuGetInfo( &cpuinfo );
+  /* Set Startup Time */
+  bsSetStartupTime();
 
 #if ENABLE_DEBUG_TRACKING
   debugTrackerInit( BS_DEBUG_TRACKER_WATCH_MILLISECONDS, BS_DEBUG_TRACKER_STALL_MILLISECONDS );

--- a/bricksync.h
+++ b/bricksync.h
@@ -683,6 +683,7 @@ int bsSubmitBrickOwlEditWeight( bsContext *context, bsxItem *item, float itemwei
 
 int bsParseInput( bsContext *context, int *retactionflag );
 
+void bsSetStartupTime();
 void bsCommandStatus( bsContext *context, int argc, char **argv );
 void bsCommandRegister( bsContext *context, int argc, char **argv );
 void bsCommandPruneBackups( bsContext *context, int argc, char **argv );

--- a/bricksyncinput.c
+++ b/bricksyncinput.c
@@ -863,6 +863,13 @@ static void bsPrintHelpItemCommand( bsContext *context, char *command, char *suf
 
 ////
 
+static char BS_STARTUP_TIME[64];
+void bsSetStartupTime() {
+    time_t t = time(NULL);
+    struct tm *tm = localtime(&t);
+    size_t ret = strftime(BS_STARTUP_TIME, sizeof(BS_STARTUP_TIME), "%Y-%m-%d %H:%M:%S", tm);
+    assert(ret);
+}
 
 void bsCommandStatus( bsContext *context, int argc, char **argv )
 {
@@ -872,13 +879,7 @@ void bsCommandStatus( bsContext *context, int argc, char **argv )
   ccGrowth growth;
   char *colorstring;
   float apihistoryratio;
-  // Set the current date and time for printout in the startup message
-  time_t t = time(NULL);
-  struct tm *tm = localtime(&t);
-  char cur_date_time[64];
-  size_t ret = strftime(cur_date_time, sizeof(cur_date_time), "%Y-%m-%d %H:%M:%S", tm);
-  // validate pointer to the time value
-  assert(ret);
+
 
   if( !( bsCmdArgStdParse( context, argc, argv, 0, 0, 0, &cmdflags, BS_COMMAND_ARGSTD_FLAG_SHORT ) ) )
   {
@@ -891,7 +892,7 @@ void bsCommandStatus( bsContext *context, int argc, char **argv )
   if( !( cmdflags & BS_COMMAND_ARGSTD_FLAG_SHORT ) )
     ioPrintf( &context->output, 0, BSMSG_INFO "BrickSync Status Report.\n" );
   ioPrintf( &context->output, 0, BSMSG_INFO "Software version : " IO_GREEN "%s" IO_DEFAULT " - " IO_GREEN "%s %s" IO_DEFAULT ".\n", BS_VERSION_STRING, __DATE__, __TIME__ );
-  ioPrintf( &context->output, 0, BSMSG_INFO "Software launch time : " IO_CYAN "%s" IO_DEFAULT ".\n", cur_date_time);
+  ioPrintf( &context->output, 0, BSMSG_INFO "Software launch time : " IO_CYAN "%s" IO_DEFAULT ".\n", BS_STARTUP_TIME);
 
   if( ( context->storename ) && ( context->username ) )
     ioPrintf( &context->output, 0, BSMSG_INFO "Store name : " IO_GREEN "%s" IO_DEFAULT " by " IO_GREEN "%s" IO_DEFAULT ".\n", context->storename, context->username );


### PR DESCRIPTION
The Software launch time was inaccurately reporting the current date/time versus the actual launch time when the 'status' command was called. This is a patch to correct that issue.